### PR TITLE
Correct README and change -i output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A typical experimental setup, where the digital anttenuator is connecto to a Lap
 
 1. start our tool with  "sudo ./attenuator_lab_brick -h" to get a list of supported commands
 2. either you set the attenuation level directly or for more complex attenuation patters via a csv file
-3. we support rigth now full dB values only, where the minimum is 0dB and the maximum is 63dB
+3. You can get the attenuator frequency resolution with sudo ./attenuator_lab_brck -i. We do support 0.25dB steps
 
 ## Example usage with a csv file
 

--- a/src/control.c
+++ b/src/control.c
@@ -768,7 +768,7 @@ handle_single_dev(struct user_data *ud, int argc, char *argv[], DEVID *working_d
 
 	print_dev_info(SINGLE_DEV);
 	if (ud->info)
-		print_userdata(ud);
+		print_dev_info(SINGLE_DEV_ID);
 	status = fnLDA_InitDevice(working_devices[SINGLE_DEV]);
 	if (status != 0) {
 		printf("initialising device 1 failed\n");

--- a/src/control.c
+++ b/src/control.c
@@ -75,11 +75,12 @@ susleep(unsigned long usec)
 void
 print_dev_info(int id)
 {
-	if ((fnLDA_GetAttenuation(id) / 4) < 0)
-		printf("Attenuation is set to 0dB\n");
-	else
-		printf("Attenuation is set to: %.2fdB\n",
-		       (double)(fnLDA_GetAttenuation(id) / 4));
+	printf("You can set attenuation steps in %.2fdB steps\n",
+		(double)(fnLDA_GetDevResolution(SINGLE_DEV_ID)) / 4);
+	printf("min attenuation: %.2fdB\n",
+		(double)fnLDA_GetMinAttenuation(id) / 4);
+	printf("max attenuation: %.2fdB\n",
+		(double)fnLDA_GetMaxAttenuation(id) / 4);
 }
 
 /*
@@ -626,7 +627,6 @@ start_device(void *arguments)
 {
 	struct thread_arguments *args = arguments;
 	struct user_data *ud = allocate_user_data();
-	printf("size of user_data %ld\n",sizeof(struct user_data));
 	clear_userdata(ud);
 	read_file(args->path, args->id, ud);
 	free(ud);
@@ -684,11 +684,6 @@ handle_multi_dev(int argc, char *argv[])
 	get_serial_and_name(device_count, device_name);
 	nr_active_devices = fnLDA_GetDevInfo(working_devices);
 	printf("%d active devices found\n", nr_active_devices);
-
-	for (id = 0; id <= nr_active_devices; id++) {
-		if ((strncmp(argv[1], "-i", strlen(argv[1]))) == 0)
-			print_dev_info(id);
-	}
 
 	/*
 	 * initiate devices
@@ -766,9 +761,6 @@ handle_single_dev(struct user_data *ud, int argc, char *argv[], DEVID *working_d
 		exit(1);
 	}
 
-	print_dev_info(SINGLE_DEV);
-	if (ud->info)
-		print_dev_info(SINGLE_DEV_ID);
 	status = fnLDA_InitDevice(working_devices[SINGLE_DEV]);
 	if (status != 0) {
 		printf("initialising device 1 failed\n");
@@ -776,9 +768,9 @@ handle_single_dev(struct user_data *ud, int argc, char *argv[], DEVID *working_d
 	}
 	else
 		printf("initialized device %d successfully\n", SINGLE_DEV_ID);
+
 	if (ud->info)
-		printf("You can set attenuation steps in %.2fdB steps\n",
-			(double)(fnLDA_GetDevResolution(SINGLE_DEV_ID)) / 4);
+		print_dev_info(SINGLE_DEV_ID);
 
 	strncpy(message, get_device_data(working_devices[SINGLE_DEV]),
 		sizeof(message));
@@ -849,11 +841,6 @@ main(int argc, char *argv[])
 	get_serial_and_name(device_count, device_name);
 	nr_active_devices = fnLDA_GetDevInfo(working_devices);
 	printf("%d active devices found\n", nr_active_devices);
-
-	if ((strncmp(argv[1], "-i", strlen(argv[1]))) == 0) {
-		for (id = 0; id < nr_active_devices; id++)
-			print_dev_info(id);
-	}
 
 	handle_single_dev(ud, argc, argv, working_devices);
 	free(ud);

--- a/src/input.c
+++ b/src/input.c
@@ -239,57 +239,6 @@ get_parameters(int argc, char *argv[], struct user_data *ud)
 	return 1;
 }
 
-/* 
- * print data set by user
- * @param ud: user data struct
- */
-void
-print_userdata(struct user_data *ud)
-{
-	printf("return address start print: %p\n", __builtin_return_address(0));
-	printf("printing user data\n");
-	char tu[20];
-
-	if (ud->us)
-		strncpy(tu ,"microseconds\0", sizeof(tu));
-	else if(ud->ms)
-		strncpy(tu ,"milliseconds\0", sizeof(tu));
-	else
-		strncpy(tu ,"seconds\0", sizeof(tu));
-
-	if (ud->simple == 1) {
-		printf("attenuation set to %.2fdB\n", (double)ud->attenuation / 4);
-		if (ud->atime != 0)
-			printf("time for attenuation set to %ld %s \n", ud->atime, tu);
-	}
-	if (ud->ramp == 1) {
-		printf("attenuation set to ramp\n");
-		printf("ramp steps set to %.2fdB\n", (double)ud->ramp_steps / 4);
-		printf("start attenuation set to %.2fdB\n", (double)ud->start_att / 4);
-		printf("end attenuation set to %.2fdB\n", (double)ud->end_att / 4);
-		printf("time per step set to %ld %s\n", ud->atime, tu);
-	}
-	if (ud->triangle == 1) {
-		printf("attenuation form set to both sided ramp\n");
-		printf("ramp steps set to %.2fdB\n", (double)ud->ramp_steps / 4);
-		printf("start attenuation set to %.2fdB\n", (double)ud->start_att / 4);
-		printf("maximal attenuation set to %.2fdB\n", (double)ud->end_att / 4);
-		printf("time per step set to %ld %s\n", ud->atime, tu);
-	}
-	if (ud->cont == 1)
-		printf("continous behavior is set\n");
-		if (ud->runs > 1)
-			printf("for %d runs\n", ud->runs);
-	if (ud->sine == 1)
-		printf("attenuation set to sine\n");
-
-	printf("printing file path\n");
-	if (ud->file == 1)
-		printf("path to config file: %s\n", ud->path);
-	printf("return address end print: %p\n", __builtin_return_address(0));
-	printf("printing user data\n");
-}
-
 /*
  * reset user data
  * @param ud: user data struct


### PR DESCRIPTION
This Pull request removes the print_userdata function and changes the way the -i flag works.
By now the -i flag will show min/max attenuation and the resolution of the attenuator in use.
This works only for single devices by now as the program flow for multi devices is different to the single device one. 
