### PR TITLE
Fix multi device handling + add multiplier step to set db attenuation.

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -76,11 +76,11 @@ void
 print_dev_info(int id)
 {
 	printf(INFO "You can set attenuation steps in %.2fdB steps\n",
-		(double)(fnLDA_GetDevResolution(SINGLE_DEV_ID)) / 4);
+		(double)(fnLDA_GetDevResolution(SINGLE_DEV_ID)) / MULTIPLIER_STEP);
 	printf(INFO "min attenuation: %.2fdB\n",
-		(double)fnLDA_GetMinAttenuation(id) / 4);
+		(double)fnLDA_GetMinAttenuation(id) / MULTIPLIER_STEP);
 	printf(INFO "max attenuation: %.2fdB\n",
-		(double)fnLDA_GetMaxAttenuation(id) / 4);
+		(double)fnLDA_GetMaxAttenuation(id) / MULTIPLIER_STEP);
 }
 
 /*
@@ -240,18 +240,18 @@ check_att_limits(int id, struct user_data *ud, int check)
 	if (check == 0) {
 		if (ud->attenuation < fnLDA_GetMinAttenuation(id)) {
 			printf(WARN "%.2f is below minimal attenuation of %.2f\n",
-				(double)ud->attenuation / 4,
-				(double)fnLDA_GetMinAttenuation(id) / 4);
+				(double)ud->attenuation / MULTIPLIER_STEP,
+				(double)fnLDA_GetMinAttenuation(id) / MULTIPLIER_STEP);
 			printf(WARN "attenuation has been set to %.2fdB\n",
-				(double)fnLDA_GetMinAttenuation(id) / 4);
+				(double)fnLDA_GetMinAttenuation(id) / MULTIPLIER_STEP);
 			fnLDA_SetAttenuation(id, fnLDA_GetMinAttenuation(id));
 			log_attenuation(fnLDA_GetMinAttenuation(id), ud);
 		} else if (ud->attenuation > fnLDA_GetMaxAttenuation(id)) {
 			printf(WARN "%.2f is above maximal attenuation of %.2f\n",
-				(double)ud->attenuation / 4,
-				(double)fnLDA_GetMaxAttenuation(id) / 4);
+				(double)ud->attenuation / MULTIPLIER_STEP,
+				(double)fnLDA_GetMaxAttenuation(id) / MULTIPLIER_STEP);
 			printf(WARN "attenuation has been set to %.2f\n",
-				(double)fnLDA_GetMaxAttenuation(id) / 4);
+				(double)fnLDA_GetMaxAttenuation(id) / MULTIPLIER_STEP);
 			fnLDA_SetAttenuation(id, fnLDA_GetMaxAttenuation(id));
 			log_attenuation(fnLDA_GetMaxAttenuation(id), ud);
 		} else {
@@ -259,7 +259,7 @@ check_att_limits(int id, struct user_data *ud, int check)
 			log_attenuation(ud->attenuation, ud);
 			if (!ud->quiet)
 				printf(INFO "set device to %.2fdB attenuation\n",
-					(double)(fnLDA_GetAttenuation(id)) / 4);
+					(double)(fnLDA_GetAttenuation(id)) / MULTIPLIER_STEP);
 		}
 	}
 
@@ -267,34 +267,34 @@ check_att_limits(int id, struct user_data *ud, int check)
 	if (check == 1) {
 		if (ud->start_att < fnLDA_GetMinAttenuation(id)) {
 			printf(WARN "%.2f is below minimal attenuation of %.2f\n",
-				(double)ud->start_att / 4,
-				(double)fnLDA_GetMinAttenuation(id) / 4);
+				(double)ud->start_att / MULTIPLIER_STEP,
+				(double)fnLDA_GetMinAttenuation(id) / MULTIPLIER_STEP);
 			printf(WARN "start attenuation has been set to %.2fdB\n",
-				(double)fnLDA_GetMinAttenuation(id) / 4);
+				(double)fnLDA_GetMinAttenuation(id) / MULTIPLIER_STEP);
 			ud->start_att = fnLDA_GetMinAttenuation(id);
 		}
 		if (ud->start_att > fnLDA_GetMaxAttenuation(id)) {
 			printf(WARN "%.2f is above maximal attenuation of %.2f\n",
-				(double)ud->start_att / 4, 
-				(double)fnLDA_GetMaxAttenuation(id) / 4);
+				(double)ud->start_att / MULTIPLIER_STEP, 
+				(double)fnLDA_GetMaxAttenuation(id) / MULTIPLIER_STEP);
 			printf(WARN "start attenuation has been set to %.2f\n",
-				(double)fnLDA_GetMaxAttenuation(id) / 4);
+				(double)fnLDA_GetMaxAttenuation(id) / MULTIPLIER_STEP);
 			ud->start_att = fnLDA_GetMaxAttenuation(id);
 		}
 		if (ud->end_att < fnLDA_GetMinAttenuation(id)) {
 			printf(WARN "%.2f is below minumal attenuation of %.2f\n",
-				(double)ud->end_att / 4,
-				(double)fnLDA_GetMinAttenuation(id) / 4);
+				(double)ud->end_att / MULTIPLIER_STEP,
+				(double)fnLDA_GetMinAttenuation(id) / MULTIPLIER_STEP);
 			printf(WARN "final attenuation has been set to %.2fdB\n",
-				(double)fnLDA_GetMinAttenuation(id) / 4);
+				(double)fnLDA_GetMinAttenuation(id) / MULTIPLIER_STEP);
 			ud->end_att = fnLDA_GetMinAttenuation(id);
 		}
 		if (ud->end_att > fnLDA_GetMaxAttenuation(id)) {
 			printf(WARN "%.2f is above maximal attenuation of %.2f\n",
-				(double)ud->end_att / 4,
-				(double)fnLDA_GetMaxAttenuation(id) / 4);
+				(double)ud->end_att / MULTIPLIER_STEP,
+				(double)fnLDA_GetMaxAttenuation(id) / MULTIPLIER_STEP);
 			printf(WARN "final attenuation has been set to %.2f\n",
-				(double)fnLDA_GetMaxAttenuation(id) / 4);
+				(double)fnLDA_GetMaxAttenuation(id) / MULTIPLIER_STEP);
 			ud->end_att = fnLDA_GetMaxAttenuation(id);
 		}
 	}
@@ -313,7 +313,7 @@ check_stepsize(struct user_data *ud, int id)
 		if (ud->ramp_steps > (ud->start_att - ud->end_att))
 			ud->ramp_steps = ud->start_att - ud->end_att;
 	}
-	printf(WARN "step size was to large. reduced to %d\n",ud->ramp_steps / 4);
+	printf(WARN "step size was to large. reduced to %d\n",ud->ramp_steps / MULTIPLIER_STEP);
 }
 
 /*
@@ -377,12 +377,12 @@ set_ramp(int id, struct user_data *ud)
 					cur_att + ud->ramp_steps);
 				if (!ud->quiet)
 					printf(INFO "attenuation set to %.2fdB\n",
-						((double)cur_att) / 4);
+						((double)cur_att) / MULTIPLIER_STEP);
 				log_attenuation(cur_att + ud->ramp_steps, ud);
 			}
 			cur_att = fnLDA_GetAttenuation(id);
 			if (!ud->quiet)
-				printf(INFO "attenuation set to %.2fdB\n", ((double)cur_att) / 4);
+				printf(INFO "attenuation set to %.2fdB\n", ((double)cur_att) / MULTIPLIER_STEP);
 		}
 	}
 	if (ud->cont && (ud->start_att > ud->end_att)) {
@@ -396,13 +396,13 @@ set_ramp(int id, struct user_data *ud)
 					cur_att - ud->ramp_steps);
 				if (!ud->quiet)
 					printf(INFO "attenuation set to %.2fdB\n",
-						((double)cur_att) / 4);
+						((double)cur_att) / MULTIPLIER_STEP);
 				log_attenuation(cur_att - ud->ramp_steps, ud);
 			}
 			cur_att = fnLDA_GetAttenuation(id);
 			if (!ud->quiet)
 				printf(INFO "attenuation set to %.2fdB\n",
-					((double)cur_att) / 4);
+					((double)cur_att) / MULTIPLIER_STEP);
 		}
 	}
 	if (ud->start_att < ud->end_att) {
@@ -415,7 +415,7 @@ set_ramp(int id, struct user_data *ud)
 				cur_att + ud->ramp_steps);
 			if (!ud->quiet)
 				printf(INFO "attenuation set to %.2fdB\n",
-					((double)cur_att) / 4);
+					((double)cur_att) / MULTIPLIER_STEP);
 			log_attenuation(cur_att + ud->ramp_steps, ud);
 		}
 	}
@@ -429,7 +429,7 @@ set_ramp(int id, struct user_data *ud)
 				cur_att - ud->ramp_steps);
 			if (!ud->quiet)
 				printf(INFO "attenuation set to %.2fdB\n",
-					((double)cur_att) / 4);
+					((double)cur_att) / MULTIPLIER_STEP);
 			log_attenuation(cur_att - ud->ramp_steps, ud);
 		}
 	}
@@ -437,7 +437,7 @@ set_ramp(int id, struct user_data *ud)
 	cur_att = fnLDA_GetAttenuation(id);
 	if (!ud->quiet)
 		printf(INFO "attenuation set to %.2fdB\n",
-			((double)cur_att) / 4);
+			((double)cur_att) / MULTIPLIER_STEP);
 
 	return 0;
 }
@@ -488,7 +488,7 @@ set_triangle(int id, struct user_data *ud)
 				cur_att = fnLDA_GetAttenuation(id);
 				if (!ud->quiet)
 					printf(INFO "attenuation set to %.2fdB\n",
-						((double)cur_att) / 4);
+						((double)cur_att) / MULTIPLIER_STEP);
 				fnLDA_SetAttenuation(id,
 					cur_att + ud->ramp_steps);
 				log_attenuation(cur_att + ud->ramp_steps, ud);
@@ -498,7 +498,7 @@ set_triangle(int id, struct user_data *ud)
 				cur_att = fnLDA_GetAttenuation(id);
 				if (!ud->quiet)
 					printf(INFO "attenuation set to %.2fdB\n",
-						((double)cur_att) / 4);
+						((double)cur_att) / MULTIPLIER_STEP);
 				fnLDA_SetAttenuation(id,
 					cur_att - ud->ramp_steps);
 				log_attenuation(cur_att - ud->ramp_steps, ud);
@@ -513,7 +513,7 @@ set_triangle(int id, struct user_data *ud)
 			cur_att = fnLDA_GetAttenuation(id);
 			if (!ud->quiet)
 				printf(INFO "attenuation set to %.2fdB\n",
-					((double)cur_att) / 4);
+					((double)cur_att) / MULTIPLIER_STEP);
 			fnLDA_SetAttenuation(id, cur_att + ud->ramp_steps);
 			log_attenuation(cur_att + ud->ramp_steps, ud);
 		}
@@ -522,7 +522,7 @@ set_triangle(int id, struct user_data *ud)
 			cur_att = fnLDA_GetAttenuation(id);
 			if (!ud->quiet)
 				printf(INFO "attenuation set to %.2fdB\n",
-					((double)cur_att) / 4);
+					((double)cur_att) / MULTIPLIER_STEP);
 			fnLDA_SetAttenuation(id, cur_att - ud->ramp_steps);
 			log_attenuation(cur_att - ud->ramp_steps, ud);
 		}
@@ -536,7 +536,7 @@ set_triangle(int id, struct user_data *ud)
 				cur_att = fnLDA_GetAttenuation(id);
 				if (!ud->quiet)
 					printf(INFO "attenuation set to %.2fdB\n",
-						((double)cur_att) / 4);
+						((double)cur_att) / MULTIPLIER_STEP);
 				fnLDA_SetAttenuation(id,
 					cur_att - ud->ramp_steps);
 				log_attenuation(cur_att - ud->ramp_steps, ud);
@@ -546,7 +546,7 @@ set_triangle(int id, struct user_data *ud)
 				cur_att = fnLDA_GetAttenuation(id);
 				if (!ud->quiet)
 					printf(INFO "attenuation set to %.2fdB\n",
-						((double)cur_att) / 4);
+						((double)cur_att) / MULTIPLIER_STEP);
 				fnLDA_SetAttenuation(id,
 					cur_att + ud->ramp_steps);
 				log_attenuation(cur_att + ud->ramp_steps, ud);
@@ -561,7 +561,7 @@ set_triangle(int id, struct user_data *ud)
 			cur_att = fnLDA_GetAttenuation(id);
 			if (!ud->quiet)
 				printf(INFO "attenuation set to %.2fdB\n",
-					((double)cur_att) / 4);
+					((double)cur_att) / MULTIPLIER_STEP);
 			fnLDA_SetAttenuation(id, cur_att - ud->ramp_steps);
 			log_attenuation(cur_att - ud->ramp_steps, ud);
 		}
@@ -570,7 +570,7 @@ set_triangle(int id, struct user_data *ud)
 			cur_att = fnLDA_GetAttenuation(id);
 			if (!ud->quiet)
 				printf(INFO "attenuation set to %.2fdB\n",
-					((double)cur_att) / 4);
+					((double)cur_att) / MULTIPLIER_STEP);
 			fnLDA_SetAttenuation(id, cur_att + ud->ramp_steps);
 			log_attenuation(cur_att + ud->ramp_steps, ud);
 		}
@@ -580,7 +580,7 @@ set_triangle(int id, struct user_data *ud)
 	attenuation_time(ud);
 	cur_att = fnLDA_GetAttenuation(id);
 	if (!ud->quiet)
-		printf(INFO "attenuation set to %.2fdB\n", ((double)cur_att) / 4);
+		printf(INFO "attenuation set to %.2fdB\n", ((double)cur_att) / MULTIPLIER_STEP);
 	return 0;
 }
 

--- a/src/input.c
+++ b/src/input.c
@@ -60,7 +60,7 @@ read_file(char *path, int id,struct user_data *ud)
 		tmp = strdup(line);
 		ud->atime = atol(get_entry(tmp, TIME));
 		tmp = strdup(line);
-		ud->attenuation = (int)(atof(get_entry(tmp, ATT))* 4);
+		ud->attenuation = (int)(atof(get_entry(tmp, ATT))* MULTIPLIER_STEP);
 		set_attenuation(id, ud);
 		free(tmp);
 	}
@@ -101,7 +101,7 @@ log_attenuation(unsigned int att, struct user_data *ud)
                 return 2;
         }
 
-	double real_att = (double) att / 4;
+	double real_att = (double) att / MULTIPLIER_STEP;
         struct timespec ts;
         clock_gettime (CLOCK_REALTIME, &ts);
         fprintf (fp, "%u.%09u,", (unsigned int) ts.tv_sec, (unsigned int) ts.tv_nsec);
@@ -130,7 +130,7 @@ get_parameters(int argc, char *argv[], struct user_data *ud)
 		if (strncmp(argv[i], "-a", strlen(argv[i])) == 0) {
 			ud->simple = 1;
 			if ((i + 1) < argc)
-				ud->attenuation = (int)(atof(argv[i + 1]) * 4);
+				ud->attenuation = (int)(atof(argv[i + 1]) * MULTIPLIER_STEP);
 			else {
 				printf(ERR "you set the -a switch, but missed to enter an attenuation\n");
 				return 0;
@@ -146,7 +146,7 @@ get_parameters(int argc, char *argv[], struct user_data *ud)
 			}
 		} else if (strncmp(argv[i], "-step", strlen(argv[i])) == 0) {
 			if ((i + 1) < argc)
-				ud->ramp_steps = (int)(atof(argv[i + 1]) * 4);
+				ud->ramp_steps = (int)(atof(argv[i + 1]) * MULTIPLIER_STEP);
 			else {
 				printf(WARN "no attenuation steps set\n");
 				printf(WARN "Step size will be set to device minimum\n");
@@ -154,14 +154,14 @@ get_parameters(int argc, char *argv[], struct user_data *ud)
 			}
 		} else if (strncmp(argv[i], "-start", strlen(argv[i])) == 0) {
 			if ((i + 1) < argc)
-				ud->start_att = (int)(atof(argv[i + 1]) * 4);
+				ud->start_att = (int)(atof(argv[i + 1]) * MULTIPLIER_STEP);
 			else {
 				printf(ERR "no start attenuation set\n");
 				return 0;
 			}
 		} else if (strncmp(argv[i], "-end", strlen(argv[i])) == 0) {
 			if ((i + 1) < argc)
-				ud->end_att = (int)(atof(argv[i + 1]) * 4);
+				ud->end_att = (int)(atof(argv[i + 1]) * MULTIPLIER_STEP);
 			else {
 				printf(ERR "no end attenuation set\n");
 				return 0;

--- a/src/input.h
+++ b/src/input.h
@@ -5,6 +5,14 @@
 #define TIME_MILLIS(step_time) (step_time * 1000)
 #define TIME_SECONDS(step_time) (step_time * 1000000)
 #define MAX_LENGTH 128
+
+/* 
+ * Variable attenuation steps according to Vaunix LDA Linux SDK
+ * Attenuation setting in 0.25dB, so 4 steps = 1 dB
+ * Attenuation setting in 0.05dB, so 20 steps = 1 dB
+ * */
+#define MULTIPLIER_STEP 20
+
 struct user_data
 {
 	unsigned long atime;


### PR DESCRIPTION
**Fix multi device handling.**
Fix device id management.
Improve prints to associate specific device to id.
Code cleaning.

**Add multiplier step to set db attenuation.**
Recent Vaunix SDK is using 0.0.5dB as attenuation step while old APIs
use 0.25db as attenation step.
Add global variable in order to set the attenuation step multiplier
according to used SDK version.